### PR TITLE
Change 'Fedora' to 'Arch Linux' in install.sh comment

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -8,7 +8,7 @@ fi
 if ! [ -z `which dnf 2> /dev/null` ]; # Fedora
     then sudo dnf install python3 python3-tkinter python3-requests openvpn wget unzip 2> /dev/null
 fi
-if ! [ -z `which pacman 2> /dev/null` ]; # Fedora
+if ! [ -z `which pacman 2> /dev/null` ]; # Arch Linux
     then sudo pacman -Sy python3 tk python-requests openvpn wget unzip 2> /dev/null
 fi
 


### PR DESCRIPTION
I noticed that the comment on the `if` statement for 'Arch' was set to 'Fedora'. I know it's a silly little change but I thought I'd go for it.